### PR TITLE
fix: metrics retention will now use specific version

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.8.9
+version: 4.8.10
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/elastisys_custom/metrics_retention/cronjob.yaml
+++ b/charts/influxdb/templates/elastisys_custom/metrics_retention/cronjob.yaml
@@ -25,7 +25,8 @@ spec:
                 name: influxdb-metrics-retention-script
           containers:
             - name: {{ template "influxdb.fullname" $ }}-metrics-retention-{{ $key | replace "_" " " | initials }}
-              image: elastisys/influxdb-metrics-retention:latest
+              image: elastisys/influxdb-metrics-retention:0.1.0
+              imagePullPolicy: IfNotPresent
               command: ["python3", "/app/influxdb_size_based_metrics_retention.py"]
               env:
               - name: INFLUXDB_HOST


### PR DESCRIPTION
Pinned the metrics retention to a specific image version and added `imagePullPolicy: IfNotPresent`.