### PR TITLE
Added possibility to purge influxDB backups after uploaded to cloud

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.8.11
+version: 4.8.11+esys2
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/backup-cronjob.yaml
+++ b/charts/influxdb/templates/backup-cronjob.yaml
@@ -76,6 +76,11 @@ spec:
                 gcloud auth activate-service-account --key-file $KEY_FILE
               fi
               gsutil -m cp -r /backup/* "$DST_URL"
+              {{- if .Values.backup.persistence.purge }}
+              if [ $? -eq 0 ]; then
+                rm -rf /backup/*
+              fi
+              {{- end }}
             volumeMounts:
             - name: backup
               mountPath: /backup
@@ -103,6 +108,11 @@ spec:
             - |
               az storage container create --name "$DST_CONTAINER"
               az storage blob upload-batch --destination "$DST_CONTAINER" --destination-path "$DST_PATH" --source "$SRC_URL"
+              {{- if .Values.backup.persistence.purge }}
+              if [ $? -eq 0 ]; then
+                rm -rf /backup/*
+              fi
+              {{- end }}
             volumeMounts:
             - name: backup
               mountPath: /backup
@@ -130,6 +140,11 @@ spec:
             - '-c'
             - |
               aws {{- if .Values.backup.s3.endpointUrl }} --endpoint-url={{ .Values.backup.s3.endpointUrl }} {{- end }} s3 cp --recursive "$SRC_URL" "$DST_URL"
+              {{- if .Values.backup.persistence.purge }}
+              if [ $? -eq 0 ]; then
+                rm -rf /backup/*
+              fi
+              {{- end }}
             volumeMounts:
             - name: backup
               mountPath: /backup

--- a/charts/influxdb/values.yaml
+++ b/charts/influxdb/values.yaml
@@ -323,6 +323,9 @@ backup:
     ##   GKE, AWS & OpenStack)
     ##
     # storageClass: "-"
+
+    # If the backup should be deleted locally after it has been uploaded to the cloud.
+    purge: false
     annotations:
     accessMode: ReadWriteOnce
     size: 8Gi


### PR DESCRIPTION
Fix for the issue of the ever increasing backup volume.

I have not tested this yet, hence the draft. I just want some quick feedback.