### PR TITLE
Moved the rm command to before taking backup

### DIFF
--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: influxdb
-version: 4.8.12
+version: 4.8.13
 appVersion: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:

--- a/charts/influxdb/templates/backup-cronjob.yaml
+++ b/charts/influxdb/templates/backup-cronjob.yaml
@@ -58,6 +58,7 @@ spec:
             args:
             - '-c'
             - |
+              rm -rf /backup/*
               influxd backup \
                 -host {{ include "influxdb.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.config.rpc.bind_address | default 8088 }} \
                 -portable /backup/"$(date +%Y%m%d%H%M%S)"
@@ -77,7 +78,6 @@ spec:
                 gcloud auth activate-service-account --key-file $KEY_FILE
               fi
               gsutil -m cp -r /backup/* "$DST_URL"
-              rm -rf /backup/*
             volumeMounts:
             - name: backup
               mountPath: /backup
@@ -106,7 +106,6 @@ spec:
             - |
               az storage container create --name "$DST_CONTAINER"
               az storage blob upload-batch --destination "$DST_CONTAINER" --destination-path "$DST_PATH" --source "$SRC_URL"
-              rm -rf /backup/*
             volumeMounts:
             - name: backup
               mountPath: /backup
@@ -135,7 +134,6 @@ spec:
             - '-e'
             - |
               aws {{- if .Values.backup.s3.endpointUrl }} --endpoint-url={{ .Values.backup.s3.endpointUrl }} {{- end }} s3 cp --recursive "$SRC_URL" "$DST_URL"
-              rm -rf /backup/*
             volumeMounts:
             - name: backup
               mountPath: /backup


### PR DESCRIPTION
It makes more sense to remove the backups before the backup rather than after. This means that we can investigate the last backup if anything seems sketchy.
It should also fix the issue were the backups aren't deleted after the backup. 